### PR TITLE
Fix query string concatenation in Uris utility

### DIFF
--- a/landerist_library/Tools/Uris.cs
+++ b/landerist_library/Tools/Uris.cs
@@ -39,7 +39,14 @@
             }
 
             string newQuery = string.Join("&", dictionary.Select(p => $"{p.Key}={p.Value}"));
-            newQuery += string.Join("&", hashSet.ToList());
+            if (hashSet.Count > 0)
+            {
+                if (newQuery.Length > 0)
+                {
+                    newQuery += "&";
+                }
+                newQuery += string.Join("&", hashSet);
+            }
             return newQuery;
         }
     }


### PR DESCRIPTION
## Summary
- ensure query parameters without values are appended with a leading `&` when needed

## Testing
- `dotnet test` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684003d0ad7c8332a5e016e1fc2e9edd