### PR TITLE
Refactor Indexer URL insert to remove duplicates

### DIFF
--- a/landerist_library/Index/Indexer.cs
+++ b/landerist_library/Index/Indexer.cs
@@ -18,8 +18,7 @@ namespace landerist_library.Index
 
         public void Insert(List<string?> urls)
         {
-            urls = [.. urls.Distinct()];
-            foreach (var url in urls)
+            foreach (var url in new HashSet<string?>(urls))
             {
                 if (url != null)
                 {


### PR DESCRIPTION
## Summary
- improve deduplication when inserting URLs by using `HashSet`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68402d1d991c83328188479c0bfa6179