### PR TITLE
Improve Random usage

### DIFF
--- a/landerist_library/Database/WebsitesBlocker.cs
+++ b/landerist_library/Database/WebsitesBlocker.cs
@@ -93,7 +93,7 @@ namespace landerist_library.Database
 
         private static int RandomSecconds()
         {
-            return new Random().Next(MinSecconds, MaxSecconds);
+            return Random.Shared.Next(MinSecconds, MaxSecconds);
         }
     }
 }

--- a/landerist_library/Downloaders/Multiple/MultipleDownloader.cs
+++ b/landerist_library/Downloaders/Multiple/MultipleDownloader.cs
@@ -10,10 +10,10 @@
         {
             lock (Sync)
             {
-                var availables = Downloaders.Where(o => o.IsAvailable(useProxy)).ToList();
-                if (availables.Count != 0)
+                var availables = Downloaders.Where(o => o.IsAvailable(useProxy)).ToArray();
+                if (availables.Length != 0)
                 {
-                    return availables[new Random().Next(availables.Count)];
+                    return availables[Random.Shared.Next(availables.Length)];
                 }
 
                 int id = Downloaders.Count + 1;

--- a/landerist_library/Downloaders/Puppeteer/PuppeteerDownloader.cs
+++ b/landerist_library/Downloaders/Puppeteer/PuppeteerDownloader.cs
@@ -202,7 +202,7 @@ namespace landerist_library.Downloaders.Puppeteer
             UseProxy = useProxy;
             if (UseProxy)
             {
-                var sessionId = new Random().Next(1, 1000000);
+                var sessionId = Random.Shared.Next(1, 1_000_000);
                 ProxyCredentials = new Credentials
                 {
                     Username = $"{PrivateConfig.BRIGTHDATA_USERNAME}-session-{sessionId}",

--- a/landerist_library/Scrape/PageBlocker.cs
+++ b/landerist_library/Scrape/PageBlocker.cs
@@ -83,7 +83,7 @@ namespace landerist_library.Scrape
 
         private static int RandomSecconds()
         {
-            return new Random().Next(MinSecconds, MaxSecconds);
+            return Random.Shared.Next(MinSecconds, MaxSecconds);
         }
 
         private static void Add(Dictionary<string, DateTime> keyValuePairs, string? key, DateTime blockUntil)


### PR DESCRIPTION
## Summary
- use `Random.Shared` in PuppeteerDownloader for session ids
- rely on `Random.Shared` in downloader selection and blockers
- avoid allocating a list when picking an available downloader

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68406454fd1083329d4a5754b9c35447