### PR TITLE
Recalculate Pages.NextUpdate using page's timeline with current algorithm

### DIFF
--- a/landerist_library/Websites/Pages.cs
+++ b/landerist_library/Websites/Pages.cs
@@ -559,6 +559,11 @@ namespace landerist_library.Websites
 
         public static void UpdateNextUpdate()
         {
+            UpdatePagesNextUpdateWithCurrentAlgorithm();
+        }
+
+        public static void UpdatePagesNextUpdateWithCurrentAlgorithm()
+        {
             var pages = GetPages();
             int total = pages.Count;
             int updated = 0;
@@ -568,7 +573,9 @@ namespace landerist_library.Websites
             Parallel.ForEach(pages, page =>
             {
                 Interlocked.Increment(ref counter);
-                page.SetNextUpdate();
+                DateTime calculationDate = page.Updated ?? page.Inserted;
+                page.NextUpdate = PageNextUpdateCalculator.Calculate(page, calculationDate);
+
                 if (page.UpdateNextUpdate())
                 {
                     Interlocked.Increment(ref updated);


### PR DESCRIPTION
### Motivation
- The `NextUpdate` calculation algorithm was recently changed and must be applied consistently across existing pages using an appropriate base date instead of `DateTime.Now` to respect page history. 
- The existing `UpdateNextUpdate()` used `SetNextUpdate()` which used `DateTime.Now` as the calculation reference, so pages recalculated in bulk would not use their `Inserted/Updated` timestamps.

### Description
- Added `UpdatePagesNextUpdateWithCurrentAlgorithm()` which iterates all pages in parallel and recomputes `NextUpdate` with the current `PageNextUpdateCalculator` logic. 
- Made `UpdateNextUpdate()` delegate to `UpdatePagesNextUpdateWithCurrentAlgorithm()` to preserve compatibility. 
- The recomputation uses `DateTime calculationDate = page.Updated ?? page.Inserted;` as the base date and sets `page.NextUpdate = PageNextUpdateCalculator.Calculate(page, calculationDate);` before persisting via `page.UpdateNextUpdate()`. 
- Preserved existing parallel processing and progress/error logging.

### Testing
- Attempted to run a solution build with `dotnet build Landerist.sln`, but the environment lacks the `dotnet` CLI so the build could not be executed (`dotnet: command not found`).
- No automated tests were run in this environment due to the missing `dotnet` tool.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db68b21c288332bf4f9f00c81fa848)